### PR TITLE
Able to render links if api included links

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -21,7 +21,7 @@ export interface Book {
 
 const App: React.FC = () => {
   const [books, setBooks] = useState([])
-  const [singleBook, setSingleBook] = useState<Book>({title: '', description: '', authors: [], links: [], covers: []})
+  const [singleBook, setSingleBook] = useState<Book>({title: '', description: "" , authors: [{author: {key: ""}, type: {key: ""}}], links: [{url: "", title: "", type: ""}], covers: []})
   const [errorGetCategory, setErrorCategoryState] = useState(false)
   const [errorGetSingle, setErrorSingleState] = useState(false)
 
@@ -34,7 +34,7 @@ const App: React.FC = () => {
   const retrieveSingleBook = (id: any) => {
     getSingleBook(id)
       .then(data => setSingleBook(data))
-    //  .then(() => console.log(singleBook))
+      .then(() => console.log(singleBook))
       .catch(error => setErrorSingleState(true))
   }
 

--- a/src/Components/BookCard/BookCard.tsx
+++ b/src/Components/BookCard/BookCard.tsx
@@ -12,11 +12,11 @@ const BookCard: React.FC<Props> = ({ title, cover_id, id, authors, oneBook }) =>
 
   return (
     <Link to={`bookDetails`}>
-    <div className="book-card-grid" onClick={() => oneBook(id)}>
+    <div className="book-card-grid" onClick={() =>  oneBook(id)}>
       <div className="book-card">
         {/* <button onClick={() => oneBook(id)}>Book Info</button> */}
         <div className="book-card-inner">
-          <div className="book-card-front">
+          <div className="book-card-front" >
             <img
               className="book-cover-img"
               src={`https://covers.openlibrary.org/b/id/${cover_id}-L.jpg`}

--- a/src/Components/BookDetails/BookDetails.tsx
+++ b/src/Components/BookDetails/BookDetails.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import './BookDetails.css'
 import {Book} from '../App/App'
+
 interface SingleBookProps {
   singleBook: Book
 }
 
   const BookDetails: React.FC<SingleBookProps> = ({ singleBook }: SingleBookProps) => {
+
+
 
   return (
     <div className="book-styling">
@@ -21,7 +24,8 @@ interface SingleBookProps {
     <div className="book-detail-styling">
     <h1 className="title">{singleBook.title}</h1>
     <h2 className="author">by Jane Austen</h2>
-    <a href="https://wikipedia.com" className="links">{singleBook.links}</a>
+    {singleBook.links ? <a href={singleBook.links[0].url} className="links">Go to link </a> : null }
+    
     </div>
     </div>
     


### PR DESCRIPTION
# Pull Request Template

## Description
Please include a summary of the change and/or functionality implementation:
Fixed bug with Links. Links will render if API has any.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] open index.html
- [x] dev tools
- [ ] Cypress

## Checklist:
- [x] I have performed a self-review of my own code
- [ ] No console error messages

## Additional info
Please include any other relevant information or closed issue links here:
Cannot get all descriptions to load. Website still breaks if the description data in the api link contains an object.