### PR TITLE
Show the user a message when no overview is available

### DIFF
--- a/cypress/integration/BookCardContainer_spec.js
+++ b/cypress/integration/BookCardContainer_spec.js
@@ -1,0 +1,84 @@
+describe('BookCardContainer view', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:3000/books')
+  });
+
+  it('Should be able to view all books in a chosen category', () => {
+    cy.intercept('GET', 'https://openlibrary.org/subjects/kids.json', {
+      statusCode: 201,
+      body: {
+        name: 'biography',
+        works: [
+          {title: 'Brown Bear', cover_id: 1, key: '/works/OL503666W', authors:[{name: 'Nico'}]},
+          {title: 'Hungry Caterpillar', cover_id: 2, key: '/works/OL362702W', authors:[{name: 'Kody'}]},
+          {title: 'Cat in the Hat', cover_id: 3, key: '/works/OL107195W', authors:[{name: 'Renee'}]}
+        ]
+      }
+    })
+    cy.get('button').contains('Children').click()
+    cy.get('.book-cover-img')
+      .should('be.visible')
+      .should('have.length', 3)
+  });
+
+  beforeEach(() => {
+    cy.intercept('GET', 'https://openlibrary.org/subjects/biography.json', {
+      statusCode: 201,
+      body: {
+        name: 'children',
+        works: [
+          {title: 'Red Bear', cover_id: 4, key: '/works/OL503666W', authors:[{name: 'Sam'}]},
+          {title: 'Hungry Pig', cover_id: 5, key: '/works/OL362702W', authors:[{name: 'Sara'}]},
+          {title: 'Rat in the Hat', cover_id: 6, key: '/works/OL107195W', authors:[{name: 'Gracie'}]},
+          {title: 'Little Blue Truck', cover_id: 7, key: '/works/OL107196W', authors:[{name: 'Papa'}]}
+        ]
+      }
+    })
+    cy.get('button').contains('Biography').click()
+  });
+
+  it('Should be able to change genres by selecting a button on the navigation bar', () => {
+    cy.get('.book-cover-img')
+      .should('be.visible')
+      .should('have.length', 4)
+  });
+
+  it('Should be able to see book covers flip over and reveal the title and author', () => {
+    cy.get('img[alt="Rat in the Hat"]').trigger('mouseover')
+    cy.get('.book-card-back').contains('Rat in the Hat')
+      .should('have.class', 'book-title')
+    cy.get('.book-card-back').contains('Gracie')
+      .should('have.class', 'book-authors')
+  });
+
+  it('Should be able to click on a book cover and be linked to a new page with that book\'s details', () => {
+    cy.intercept('GET', 'https://openlibrary.org/works/OL107195W.json', {
+      statusCode: 201,
+      body: {
+        description: 'This is a great book description!',
+        title: 'Rat in the Hat',
+        covers: [6, 8, 9, 10],
+        first_publish_date: '1957',
+        links: ['www.wikipedia.com', 'www.google.com']
+      }
+    })
+    cy.get('img[alt="Rat in the Hat"]').click()
+    cy.get('.book-detail-styling')
+      .get('.title').contains('Rat in the Hat').should('be.visible')
+      .get('.publish-date').contains('1957').should('be.visible')
+      .get('.links').contains('Links outside of A Novel Idea').should('be.visible')
+    cy.get('.description').should('contain','This is a great book')
+    cy.get('.book-cover').should('be.visible')
+  });
+
+  it('Should be redirected to an error page with a 404 status code', () => {
+    cy.visit('http://localhost:3000/error')
+    cy.intercept('GET', 'https://openlibrary.org/bananas.json', {
+      statusCode: 404,
+      body: {
+        message: 'Oh no! The server is down'
+      }
+    })
+    cy.get('h1').should('contain', 'This is embarrasing!')
+  });
+});

--- a/src/Components/BookDetails/BookDetails.tsx
+++ b/src/Components/BookDetails/BookDetails.tsx
@@ -8,7 +8,17 @@ interface SingleBookProps {
 
   const BookDetails: React.FC<SingleBookProps> = ({ singleBook }: SingleBookProps) => {
 
-
+    const handleBadDescriptionData = () => {
+      if(typeof singleBook.description === "string") {
+        return <p className="description">{singleBook.description}</p>
+      } else if (typeof singleBook.description !== "string") {
+        if(!singleBook.description) {
+          return <p className="description">We're sorry. There is no description for this book</p>
+        } else {
+          return <p className="description">{singleBook.description.value}</p>
+        }
+      }
+    }
 
   return (
     <section className="book-styling">
@@ -18,8 +28,9 @@ interface SingleBookProps {
           src={`https://covers.openlibrary.org/b/id/${singleBook.covers[0]}-L.jpg`}
         />
         <div className="description-styling">Overview
-        {typeof singleBook.description === "string" ?  <p className="description">{singleBook.description}</p> : 
-        <p className="description">{singleBook.description.value}</p> }
+        {/*typeof singleBook.description === "string" ?  <p className="description">{singleBook.description}</p> :
+        <p className="description">{singleBook.description.value}</p>*/}
+        {handleBadDescriptionData()}
         </div>
       </div>
       <div className="book-detail-styling">


### PR DESCRIPTION
# Pull Request Template

## Description
When a user clicks on a book with no description, an error was being thrown. The user now sees a message appologizing for there being no description available.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] browser
- [x] console

## Checklist:
- [x] I have performed a self-review of my own code
- [x] No console error messages

## Additional info
The function I used in BookDetails called handleBadDescriptionData is a long, nested conditional. If anyone has any suggestions for refactoring it, that would be great.

closes #34 